### PR TITLE
Update oracle_operator_example.py

### DIFF
--- a/examples/oracle_operator_example.py
+++ b/examples/oracle_operator_example.py
@@ -6,7 +6,7 @@ import re
 import requests
 
 from aeternity import Config
-from aeternity import EpochClient
+from aeternity.epoch import EpochClient
 from aeternity import Oracle
 
 


### PR DESCRIPTION
Just changed the import code for line 9.
Also noticed that line 16: class Oraclefjean(Oracle): 

Cannot be inherited, does it have a parent class?