### PR TITLE
feat: name auction length

### DIFF
--- a/aeternity/aens.py
+++ b/aeternity/aens.py
@@ -88,7 +88,7 @@ class AEName:
             return defaults.NAME_BID_TIMEOUTS.get(1) + claim_height
         if name_len < 8:
             return defaults.NAME_BID_TIMEOUTS.get(4) + claim_height
-        if name_len < 31:
+        if name_len <= defaults.NAME_BID_MAX_LENGTH:
             return defaults.NAME_BID_TIMEOUTS.get(8) + claim_height
         return claim_height
 

--- a/aeternity/defaults.py
+++ b/aeternity/defaults.py
@@ -54,7 +54,7 @@ NAME_FEE_MULTIPLIER = 100000000000000
 NAME_FEE_BID_INCREMENT = 0.05  # the increment is in percentage
 # see https://github.com/aeternity/aeternity/blob/72e440b8731422e335f879a31ecbbee7ac23a1cf/apps/aecore/src/aec_governance.erl#L272
 NAME_BID_TIMEOUT_BLOCKS = 480  # ~1 day
-NAME_BID_MAX_LENGTH = 31  # this is the max length for a domain to be part of a bid
+NAME_BID_MAX_LENGTH = 12  # this is the max length for a domain to be part of a bid
 # ref: https://github.com/aeternity/aeternity/blob/72e440b8731422e335f879a31ecbbee7ac23a1cf/apps/aecore/src/aec_governance.erl#L290
 # bid ranges:
 NAME_BID_RANGES = {
@@ -94,7 +94,7 @@ NAME_BID_RANGES = {
 # ref: https://github.com/aeternity/aeternity/blob/72e440b8731422e335f879a31ecbbee7ac23a1cf/apps/aecore/src/aec_governance.erl#L273
 # name bid timeouts
 NAME_BID_TIMEOUTS = {
-    31: 0,
+    13: 0,
     8: 1 * NAME_BID_TIMEOUT_BLOCKS,  # 480 blocks
     4: 31 * NAME_BID_TIMEOUT_BLOCKS,  # 14880 blocks
     1: 62 * NAME_BID_TIMEOUT_BLOCKS,  # 29760 blocks

--- a/aeternity/node.py
+++ b/aeternity/node.py
@@ -251,7 +251,7 @@ class NodeClient:
         self.broadcast_transaction(tx)
         return tx
 
-    def wait_for_transaction(self, tx_hash, max_retries=None, polling_interval=None, confirm_transaction=False):
+    def wait_for_transaction(self, tx_hash, max_retries=None, polling_interval=None):
         """
         Wait for a transaction to be mined for an account
         The method will wait for a specific transaction to be included in the chain,
@@ -259,6 +259,10 @@ class NodeClient:
         - the chain reply with a 404 not found (the transaction was expunged)
         - the account nonce is >= of the transaction nonce (transaction is in an illegal state)
         - the ttl of the transaction or the one passed as parameter has been reached
+
+        :param tx_hash: the hash of the transaction to wait for
+        :param max_retries: the maximum number of retries to test for transaction
+        :param polling_interval: the interval between transaction polls
         :return: the block height of the transaction if it has been found
 
         Raises TransactionWaitTimeoutExpired if the transaction hasn't been found
@@ -301,6 +305,12 @@ class NodeClient:
         """
         Wait for a transaction to be confirmed by at least "key_block_confirmation_num" blocks (default 3)
         The amount of blocks can be configured in the Config object using key_block_confirmation_num parameter
+
+        :param tx_hash: the hash of the transaction to wait for
+        :param max_retries: the maximum number of retries to test for transaction
+        :param polling_interval: the interval between transaction polls
+        :return: the block height of the transaction if it has been found
+
         """
         # first wait for the transaction to be found
         tx_height = self.wait_for_transaction(tx_hash)
@@ -326,6 +336,7 @@ class NodeClient:
             total_sleep += interval
             # increment n
             n += 1
+        return tx_height
 
     def transfer_funds(self, account: Account,
                        recipient_id: str,

--- a/tests/test_aens.py
+++ b/tests/test_aens.py
@@ -24,7 +24,7 @@ def test_name_is_available(chain_fixture):
 
 
 def test_name_status_available(chain_fixture):
-    domain = random_domain(length=32 ,tld='aet' if chain_fixture.NODE_CLI.get_consensus_protocol_version() >= PROTOCOL_LIMA else 'test')
+    domain = random_domain(length=13 ,tld='aet' if chain_fixture.NODE_CLI.get_consensus_protocol_version() >= PROTOCOL_LIMA else 'test')
     name = chain_fixture.NODE_CLI.AEName(domain)
     assert name.status == AEName.Status.UNKNOWN
     name.update_status()
@@ -34,7 +34,7 @@ def test_name_status_available(chain_fixture):
 def test_name_claim_lifecycle(chain_fixture):
     try:
         # avoid auctions
-        domain = random_domain(length=32 ,tld='aet' if chain_fixture.NODE_CLI.get_consensus_protocol_version() >= PROTOCOL_LIMA else 'test')
+        domain = random_domain(length=13 ,tld='aet' if chain_fixture.NODE_CLI.get_consensus_protocol_version() >= PROTOCOL_LIMA else 'test')
         node_cli = chain_fixture.NODE_CLI
         name = node_cli.AEName(domain)
         assert name.status == AEName.Status.UNKNOWN
@@ -54,7 +54,7 @@ def test_name_auction(chain_fixture):
         skip("name auction is only supported after Lima HF")
         return
     try:
-        domain = random_domain(length=18)
+        domain = random_domain(length=12)
         node_cli = chain_fixture.NODE_CLI
         name = node_cli.AEName(domain)
         assert name.status == AEName.Status.UNKNOWN
@@ -72,7 +72,7 @@ def test_name_auction(chain_fixture):
         bid_tx = name2.bid(chain_fixture.BOB, bid)
         print("BID TX", bid_tx)
         # get the tx height
-        bid_h = node_cli.wait_for_confirmation(bid_tx.hash)
+        bid_h = node_cli.wait_for_transaction(bid_tx.hash)
         print(f"BOB BID Height is  {bid_h}")
         # now we should wait to see that bob gets the name
         bid_ends = AEName.compute_auction_end_block(domain, bid_h)
@@ -85,7 +85,7 @@ def test_name_auction(chain_fixture):
 
 def test_name_status_unavailable(chain_fixture):
     # avoid auctions
-    domain = random_domain(length=32 ,tld='aet' if chain_fixture.NODE_CLI.get_consensus_protocol_version() >= PROTOCOL_LIMA else 'test')
+    domain = random_domain(length=13 ,tld='aet' if chain_fixture.NODE_CLI.get_consensus_protocol_version() >= PROTOCOL_LIMA else 'test')
     print(f"domain is {domain}")
     occupy_name = chain_fixture.NODE_CLI.AEName(domain)
     occupy_name.full_claim_blocking(chain_fixture.ALICE)
@@ -96,7 +96,7 @@ def test_name_status_unavailable(chain_fixture):
 
 def test_name_update(chain_fixture):
     # avoid auctions
-    domain = random_domain(length=32 ,tld='aet' if chain_fixture.NODE_CLI.get_consensus_protocol_version() >= PROTOCOL_LIMA else 'test')
+    domain = random_domain(length=13 ,tld='aet' if chain_fixture.NODE_CLI.get_consensus_protocol_version() >= PROTOCOL_LIMA else 'test')
     print(f"domain is {domain}")
     name = chain_fixture.NODE_CLI.AEName(domain)
     print("Claim name ", domain)
@@ -116,7 +116,7 @@ def test_name_update(chain_fixture):
 
 def test_name_transfer_ownership(chain_fixture):
     # avoid auctions
-    domain = random_domain(length=32 ,tld='aet' if chain_fixture.NODE_CLI.get_consensus_protocol_version() >= PROTOCOL_LIMA else 'test')
+    domain = random_domain(length=13 ,tld='aet' if chain_fixture.NODE_CLI.get_consensus_protocol_version() >= PROTOCOL_LIMA else 'test')
     name = chain_fixture.NODE_CLI.AEName(domain)
     name.full_claim_blocking(chain_fixture.ALICE)
     assert name.status == AEName.Status.CLAIMED
@@ -138,7 +138,7 @@ def test_name_transfer_ownership(chain_fixture):
 
 def test_name_revocation(chain_fixture):
     # avoid auctions
-    domain = random_domain(length=32 ,tld='aet' if chain_fixture.NODE_CLI.get_consensus_protocol_version() >= PROTOCOL_LIMA else 'test')
+    domain = random_domain(length=13 ,tld='aet' if chain_fixture.NODE_CLI.get_consensus_protocol_version() >= PROTOCOL_LIMA else 'test')
     name = chain_fixture.NODE_CLI.AEName(domain)
     name.full_claim_blocking(chain_fixture.ALICE)
     name.revoke(chain_fixture.ALICE)


### PR DESCRIPTION
changes the max length for auction from 32 to 12

BREAKING CHANGES:
- `the wait_for_transaction` drops the unused parameter confirm_transaction.
- `the wait_for_confirmation` returns height where the transaction has been found (if any)