### PR TITLE
fix: compatibility range for node version

### DIFF
--- a/aeternity/__init__.py
+++ b/aeternity/__init__.py
@@ -1,6 +1,6 @@
 import pkg_resources
 
-__node_compatibility__ = (">=3.0.1", "<=5.0.0-rc.3")
+__node_compatibility__ = (">=3.0.1", "<=5.0.0")
 __compiler_compatibility__ = (">=3.2.0", "<5.0.0")
 
 

--- a/aeternity/__init__.py
+++ b/aeternity/__init__.py
@@ -1,7 +1,7 @@
 import pkg_resources
 
 __node_compatibility__ = (">=3.0.1", "<=5.0.0")
-__compiler_compatibility__ = (">=3.2.0", "<5.0.0")
+__compiler_compatibility__ = (">=3.2.0", "<6.0.0")
 
 
 def _version():


### PR DESCRIPTION
include the v5.0.0 in the compatibility range since the development is frozen in the RC3